### PR TITLE
perf(keyboard): reduce input hot-path work

### DIFF
--- a/app/src/main/java/com/kinetica/keyboard/engine/GestureStream.kt
+++ b/app/src/main/java/com/kinetica/keyboard/engine/GestureStream.kt
@@ -21,7 +21,7 @@ class GestureStream(
     val streamId: StreamId,
     val pointerId: Int,
     private val geometry: KeyboardGeometry,
-    private val tapDispKw: Float,
+    tapDispKw: Float,
     downXPx: Float,
     downYPx: Float,
     val downTime: Long,
@@ -32,7 +32,8 @@ class GestureStream(
     private val contacts = ArrayList<KeyContact>(16)
     private val downX = downXPx / geometry.keyWidthPx
     private val downY = downYPx / geometry.keyWidthPx
-    private var maxDispKw = 0f
+    private val tapDispSqKw = tapDispKw * tapDispKw
+    private var maxDispSqKw = 0f
     private var currentKey = downCode
     private var currentEnter = downTime
     private var arcLen = 0f
@@ -52,7 +53,7 @@ class GestureStream(
     }
 
     /** True once displacement rules out a tap (the UI uses this to start the trail). */
-    val isSwipeCommitted: Boolean get() = maxDispKw >= tapDispKw
+    val isSwipeCommitted: Boolean get() = maxDispSqKw >= tapDispSqKw
 
     fun addPoint(xPx: Float, yPx: Float, t: Long) {
         val x = xPx / geometry.keyWidthPx
@@ -60,15 +61,18 @@ class GestureStream(
         val last = points[points.size - 1]
         val dxl = x - last.x
         val dyl = y - last.y
-        val stepLen = sqrt(dxl * dxl + dyl * dyl)
-        if (stepLen < 1e-4f && t == last.t) return
+        val stepSq = dxl * dxl + dyl * dyl
+        if (stepSq < MIN_STEP_SQ_KW && t == last.t) return
         points.add(PathPoint(x, y, t))
-        arcLen += stepLen
+        arcLen += sqrt(stepSq)
 
+        // Tap classification and dwell membership only need radius comparisons.
+        // Keeping both sides squared removes two square roots from every raw
+        // touch sample on the UI thread; boundary behavior is locked by tests.
         val dx = x - downX
         val dy = y - downY
-        val disp = sqrt(dx * dx + dy * dy)
-        if (disp > maxDispKw) maxDispKw = disp
+        val dispSq = dx * dx + dy * dy
+        if (dispSq > maxDispSqKw) maxDispSqKw = dispSq
 
         // Before the key-contact early-outs below: a dwell must be seen on every
         // sample, including the ones that change no key.
@@ -94,7 +98,7 @@ class GestureStream(
     private fun trackDwell(idx: Int, x: Float, y: Float, t: Long) {
         val dx = x - runAnchorX
         val dy = y - runAnchorY
-        if (sqrt(dx * dx + dy * dy) <= KineticaConstants.DWELL_RADIUS_KW) {
+        if (dx * dx + dy * dy <= DWELL_RADIUS_SQ_KW) {
             runLastIdx = idx
             runLastT = t
             return
@@ -133,7 +137,7 @@ class GestureStream(
         // must not segment the gesture.
         if (currentKey != -1) contacts.add(KeyContact(currentKey, currentEnter, t))
         val dur = t - downTime
-        if (maxDispKw < tapDispKw) {
+        if (maxDispSqKw < tapDispSqKw) {
             // Spec-literal taps are <150 ms; a stationary dwell decodes exactly
             // like a zero-length swipe would, and the flag is the UI's
             // long-press hook.
@@ -152,6 +156,10 @@ class GestureStream(
     }
 
     private companion object {
+        const val MIN_STEP_SQ_KW = 1e-8f
+        val DWELL_RADIUS_SQ_KW =
+            KineticaConstants.DWELL_RADIUS_KW * KineticaConstants.DWELL_RADIUS_KW
+
         // Resampling touches no DTW row state, so one shared instance is safe
         // here as long as streams are finished on a single (UI) thread.
         val RESAMPLER = DtwMatcher()

--- a/app/src/main/java/com/kinetica/keyboard/engine/WordComposer.kt
+++ b/app/src/main/java/com/kinetica/keyboard/engine/WordComposer.kt
@@ -51,6 +51,53 @@ class WordComposer(
     private val generation = AtomicInteger()
 
     /**
+     * At most one decode worker is queued at a time. Fast tap sequences can
+     * otherwise enqueue a full dictionary decode for every letter faster than
+     * the single decode thread can consume them. Those intermediate results are
+     * stale before they even start, but they still used to run to completion and
+     * delay the only result the user can see.
+     *
+     * The pending slot is latest-wins: a running worker finishes its current
+     * predictor call (WordPredictor is thread-confined and not interruptible),
+     * then jumps directly to the newest snapshot. This bounds obsolete work to
+     * one in-flight active-language decode instead of an unbounded executor
+     * backlog. The generation checks also avoid starting the optional second-
+     * language decode once the first pass has already gone stale.
+     */
+    private data class DecodeRequest(
+        val tokens: List<InputToken>,
+        val context: List<String>,
+        val generation: Int,
+        val literal: String,
+        val alternate: WordPredictor?,
+    )
+
+    private val decodeLock = Any()
+    private var pendingDecode: DecodeRequest? = null
+    private var decodeWorkerScheduled = false
+    private val decodeWorker = Runnable {
+        try {
+            drainDecodes()
+        } finally {
+            // A predictor/main-executor failure must not strand the composer in
+            // a permanently "scheduled" state. If input arrived while the
+            // failed worker was running, hand that latest snapshot to a fresh
+            // executor task; otherwise simply reopen scheduling for the next
+            // token.
+            val reschedule = synchronized(decodeLock) {
+                decodeWorkerScheduled = false
+                if (pendingDecode != null) {
+                    decodeWorkerScheduled = true
+                    true
+                } else {
+                    false
+                }
+            }
+            if (reschedule) submitDecodeWorker()
+        }
+    }
+
+    /**
      * Second enabled language: when set, swipe-bearing words also decode
      * against it and BOTH lists are ranked together into one (see [merge]).
      * Main thread writes, decode thread reads.
@@ -113,17 +160,56 @@ class WordComposer(
 
     private fun requestDecode() {
         val snapshot = ArrayList(tokens)
-        val ctx = context.toList()
-        val gen = generation.incrementAndGet()
-        val literal = buildLiteral(snapshot)
-        val alternate = alternatePredictor
-        decodeExecutor.execute {
-            val active = predictor.decode(snapshot, ctx)
+        val request = DecodeRequest(
+            tokens = snapshot,
+            context = context.toList(),
+            generation = generation.incrementAndGet(),
+            literal = buildLiteral(snapshot),
+            alternate = alternatePredictor,
+        )
+        val scheduleWorker = synchronized(decodeLock) {
+            pendingDecode = request
+            if (decodeWorkerScheduled) {
+                false
+            } else {
+                decodeWorkerScheduled = true
+                true
+            }
+        }
+        if (scheduleWorker) submitDecodeWorker()
+    }
+
+    private fun submitDecodeWorker() {
+        try {
+            decodeExecutor.execute(decodeWorker)
+        } catch (e: RuntimeException) {
+            synchronized(decodeLock) { decodeWorkerScheduled = false }
+            throw e
+        }
+    }
+
+    private fun drainDecodes() {
+        while (true) {
+            val request = synchronized(decodeLock) {
+                pendingDecode?.also { pendingDecode = null }
+            } ?: return
+            // A clear/commit or newer token can supersede a request before its
+            // queued worker starts. Do not spend any dictionary work on it.
+            if (request.generation != generation.get()) continue
+
+            val active = predictor.decode(request.tokens, request.context)
+            // Auto-detect can double decode cost. If input advanced during the
+            // active-language pass, skip the obsolete second-language pass and
+            // immediately drain the newest snapshot instead.
+            if (request.generation != generation.get()) continue
+
+            val alternate = request.alternate
             // Cross-language ranking applies to swipe-bearing words only (empty
             // literal): all-tap words feed autocorrect, whose isWord semantics
             // are tied to the active language.
-            val merged = if (alternate != null && literal.isEmpty()) {
-                val other = alternate.decode(snapshot, ctx)
+            val merged = if (alternate != null && request.literal.isEmpty()) {
+                val other = alternate.decode(request.tokens, request.context)
+                if (request.generation != generation.get()) continue
                 merge(active, other).also { m ->
                     DecodeTrace.log {
                         val a = active.firstOrNull()
@@ -139,8 +225,11 @@ class WordComposer(
                 Merged(active, active.firstOrNull(), foreignKept = 0, reason = "single")
             }
             mainExecutor.execute {
-                if (gen == generation.get()) {
-                    callbacks.onCandidates(merged.candidates, merged.tentative, literal, gen)
+                if (request.generation == generation.get()) {
+                    callbacks.onCandidates(
+                        merged.candidates, merged.tentative,
+                        request.literal, request.generation,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/kinetica/keyboard/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kinetica/keyboard/ui/KeyboardView.kt
@@ -160,6 +160,7 @@ class KeyboardView @JvmOverloads constructor(
 
     private var layout: KeyboardLayout? = null
     private val keyRects = ArrayList<RectF>()
+    private val keyInsets = ArrayList<RectF>()
     private var uppercase = false
     private var staticLayer: Bitmap? = null
     private var engineActive = false
@@ -384,10 +385,13 @@ class KeyboardView @JvmOverloads constructor(
     private fun rebuild() {
         val l = layout ?: return
         keyRects.clear()
+        keyInsets.clear()
         val w = width.toFloat()
         val h = height.toFloat()
         for (k in l.keys) {
-            keyRects.add(LayoutTransforms.apply(layoutMode, k, w, h))
+            val rect = LayoutTransforms.apply(layoutMode, k, w, h)
+            keyRects.add(rect)
+            keyInsets.add(insetRect(rect))
         }
         buildGeometry(l)
         renderStaticLayer()
@@ -426,12 +430,11 @@ class KeyboardView @JvmOverloads constructor(
         val c = Canvas(bmp)
         c.drawRect(0f, 0f, width.toFloat(), height.toFloat(), bgPaint)
         for (i in l.keys.indices) {
-            drawKey(c, l.keys[i], keyRects[i])
+            drawKey(c, l.keys[i], keyInsets[i])
         }
     }
 
-    private fun drawKey(c: Canvas, key: Key, rect: RectF) {
-        val inset = insetRect(rect)
+    private fun drawKey(c: Canvas, key: Key, inset: RectF) {
         // Chromeless keys (apostrophe) paint no background - just the glyph on
         // the keyboard surface, so they blend in Nintype-style.
         if (!key.chromeless) {
@@ -486,7 +489,9 @@ class KeyboardView @JvmOverloads constructor(
                 if (idx !in l.keys.indices) continue
                 val key = l.keys[idx]
                 if (key.chromeless) continue
-                val inset = insetRect(keyRects[idx])
+                // Insets are immutable between rebuilds; reusing them avoids a
+                // RectF allocation on every animation frame while a key is held.
+                val inset = keyInsets[idx]
                 canvas.drawRoundRect(inset, cornerPx, cornerPx, pressedPaint)
                 val label = if (key.isLetter && uppercase) key.label.uppercase() else key.label
                 if (label.isNotEmpty() && key.type == KeyType.CHAR) {

--- a/app/src/main/java/com/kinetica/keyboard/ui/TrailRenderer.kt
+++ b/app/src/main/java/com/kinetica/keyboard/ui/TrailRenderer.kt
@@ -12,10 +12,18 @@ import com.kinetica.keyboard.engine.models.StreamId
  */
 class TrailRenderer(private val density: Float) {
 
-    private class TrailPoint(val x: Float, val y: Float, val t: Long, val hue: Float)
+    private class TrailPoint(
+        var x: Float,
+        var y: Float,
+        var t: Long,
+        var hue: Float,
+        var breakBefore: Boolean,
+    )
 
     private val trails = arrayOf(ArrayDeque<TrailPoint>(), ArrayDeque<TrailPoint>())
+    private val pointPool = ArrayDeque<TrailPoint>()
     private val hues = floatArrayOf(0f, 0f)
+    private val forceNextPoint = BooleanArray(2)
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
         strokeCap = Paint.Cap.ROUND
@@ -27,11 +35,43 @@ class TrailRenderer(private val density: Float) {
     var baseHue = 0f
 
     fun startStream(stream: StreamId) {
-        hues[stream.ordinal] = (baseHue + if (stream == StreamId.RIGHT) 60f else 0f) % 360f
+        val i = stream.ordinal
+        hues[i] = (baseHue + if (stream == StreamId.RIGHT) 60f else 0f) % 360f
+        forceNextPoint[i] = true
     }
 
     fun addPoint(stream: StreamId, x: Float, y: Float, t: Long) {
-        trails[stream.ordinal].addLast(TrailPoint(x, y, t, hues[stream.ordinal]))
+        val i = stream.ordinal
+        val trail = trails[i]
+        val hue = hues[i]
+        val last = trail.lastOrNull()
+        // MotionEvent history can deliver several samples per display frame.
+        // The decoder keeps every sample; the visual trail only needs one point
+        // per ~8 ms. Updating the endpoint preserves its current position while
+        // bounding both drawLine work and allocation pressure on high-refresh
+        // devices. Hue transitions remain exact because they force a new point.
+        if (!forceNextPoint[i] && last != null && last.hue == hue &&
+            t >= last.t && t - last.t < MIN_SAMPLE_INTERVAL_MS
+        ) {
+            last.x = x
+            last.y = y
+            last.t = t
+            return
+        }
+        val breakBefore = forceNextPoint[i]
+        forceNextPoint[i] = false
+        val point = if (pointPool.isEmpty()) {
+            TrailPoint(x, y, t, hue, breakBefore)
+        } else {
+            pointPool.removeLast().also {
+                it.x = x
+                it.y = y
+                it.t = t
+                it.hue = hue
+                it.breakBefore = breakBefore
+            }
+        }
+        trail.addLast(point)
     }
 
     fun bumpHue(stream: StreamId) {
@@ -43,7 +83,7 @@ class TrailRenderer(private val density: Float) {
         var alive = false
         for (trail in trails) {
             while (trail.isNotEmpty() && now - trail.first().t > TRAIL_LIFE_MS) {
-                trail.removeFirst()
+                recycle(trail.removeFirst())
             }
             if (trail.isNotEmpty()) alive = true
         }
@@ -51,8 +91,14 @@ class TrailRenderer(private val density: Float) {
     }
 
     fun clear() {
-        trails[0].clear()
-        trails[1].clear()
+        for (trail in trails) {
+            while (trail.isNotEmpty()) recycle(trail.removeFirst())
+        }
+        forceNextPoint.fill(false)
+    }
+
+    private fun recycle(point: TrailPoint) {
+        if (pointPool.size < MAX_POOLED_POINTS) pointPool.addLast(point)
     }
 
     fun draw(canvas: Canvas, now: Long) {
@@ -62,7 +108,7 @@ class TrailRenderer(private val density: Float) {
             for (p in trail) {
                 val a = prev
                 prev = p
-                if (a == null) continue
+                if (a == null || p.breakBefore) continue
                 val age = (now - p.t).coerceAtLeast(0)
                 val f = 1f - age / TRAIL_LIFE_MS.toFloat()
                 if (f <= 0f) continue
@@ -78,6 +124,8 @@ class TrailRenderer(private val density: Float) {
 
     private companion object {
         const val TRAIL_LIFE_MS = 250L
+        const val MIN_SAMPLE_INTERVAL_MS = 8L
+        const val MAX_POOLED_POINTS = 128
         const val HUE_STEP = 30f
     }
 }

--- a/app/src/test/java/com/kinetica/keyboard/engine/GestureStreamDwellTest.kt
+++ b/app/src/test/java/com/kinetica/keyboard/engine/GestureStreamDwellTest.kt
@@ -177,6 +177,38 @@ class GestureStreamDwellTest {
     }
 
     @Test
+    fun squaredTapThresholdKeepsBoundaryClassification() {
+        assertTrue(
+            "one ULP below the threshold must remain a tap",
+            tokenAtDisplacement(java.lang.Math.nextDown(TAP_DISP_KW)) is TapToken,
+        )
+        assertTrue(
+            "the threshold itself commits a swipe",
+            tokenAtDisplacement(TAP_DISP_KW) is SwipeToken,
+        )
+        assertTrue(
+            "one ULP above the threshold must remain a swipe",
+            tokenAtDisplacement(java.lang.Math.nextUp(TAP_DISP_KW)) is SwipeToken,
+        )
+    }
+
+    private fun tokenAtDisplacement(distanceKw: Float): InputToken {
+        // Unit key width and a zero origin avoid pixel conversion rounding, so
+        // this pins the exact float boundary used by GestureStream.
+        val geometry = KeyboardGeometry.fromPx(
+            1f, 3f,
+            listOf(floatArrayOf(-1f, -1f, 2f, 2f)),
+            intArrayOf(0),
+        )
+        val stream = GestureStream(
+            StreamId.LEFT, 0, geometry, TAP_DISP_KW,
+            0f, 0f, 0L, 0,
+        ) { }
+        stream.addPoint(distanceKw, 0f, 10L)
+        return stream.finish(10L)
+    }
+
+    @Test
     fun dwellTrackingLeavesTapClassificationAlone() {
         // A long stationary press is still a tap (classification is
         // displacement-only); dwell bookkeeping must not perturb that path.

--- a/app/src/test/java/com/kinetica/keyboard/engine/WordComposerTest.kt
+++ b/app/src/test/java/com/kinetica/keyboard/engine/WordComposerTest.kt
@@ -121,19 +121,60 @@ class WordComposerTest {
     }
 
     @Test
-    fun staleResultsAreDropped() {
-        // Queue decodes on a manual executor: both tokens arrive before either
-        // decode runs, so the first decode's result is stale by generation.
+    fun aFailedWorkerDoesNotPermanentlyStopFutureDecodes() {
+        val queued = ArrayList<Runnable>()
+        val manual = Executor { queued.add(it) }
+        var failFirst = true
+        var recoveredLiteral = ""
+        val callbacks = object : WordComposer.Callbacks {
+            override fun onCandidates(
+                candidates: List<WordCandidate>,
+                tentative: WordCandidate?,
+                literal: String,
+                generation: Int,
+            ) {
+                if (failFirst) {
+                    failFirst = false
+                    throw IllegalStateException("synthetic callback failure")
+                }
+                recoveredLiteral = literal
+            }
+        }
+        val composer = WordComposer(predictor, manual, direct, callbacks)
+        composer.onToken(TestData.tap('t', g, 0))
+        var failed = false
+        try {
+            queued.removeAt(0).run()
+        } catch (_: IllegalStateException) {
+            failed = true
+        }
+        assertTrue("the synthetic failure must reach the executor", failed)
+
+        composer.onToken(TestData.tap('h', g, 100))
+        assertEquals(1, queued.size)
+        queued.single().run()
+        assertEquals("th", recoveredLiteral)
+    }
+
+    @Test
+    fun pendingDecodesAreCoalescedToTheLatestGeneration() {
+        // Queue the worker without running it, then type several more letters.
+        // Only one executor task should exist: running it must jump directly to
+        // the latest snapshot instead of burning one full decode per stale
+        // prefix first.
         val queued = ArrayList<Runnable>()
         val manual = Executor { queued.add(it) }
         val cap = Capture()
         val composer = WordComposer(predictor, manual, direct, cap)
         composer.onToken(TestData.tap('t', g, 0))
         composer.onToken(TestData.tap('h', g, 100))
-        assertEquals(2, queued.size)
-        queued.forEach { it.run() }
-        // Only the second (current-generation) result may reach the callback.
+        composer.onToken(TestData.tap('e', g, 200))
+        assertEquals(1, queued.size)
+
+        queued.single().run()
+
         assertEquals(1, cap.calls)
-        assertEquals("th", cap.literal)
+        assertEquals("the", cap.literal)
+        assertEquals("the", cap.candidates.first().word)
     }
 }


### PR DESCRIPTION
## Summary

- coalesce pending `WordComposer` requests so burst input keeps only the latest snapshot instead of accumulating obsolete dictionary work
- skip stale alternate-language decoding and recover the decode worker after predictor, callback, executor, or submission failures
- replace per-sample tap/dwell square roots with squared-distance comparisons
- coalesce and recycle visual trail points while preserving decoder samples, hue transitions, and gesture boundaries
- cache key inset rectangles across frames instead of allocating them while keys are pressed

## Why

Kinetica decodes on a priority single-thread executor. Rapid finalized tokens could enqueue multiple full-buffer prediction requests; generation checks hid stale results, but obsolete work could still delay the newest visible result. MotionEvent history also expanded the amount of per-sample UI-thread math, trail allocation, and repeated trail drawing.

The scheduling change bounds pending prediction work to one active decode plus the newest pending snapshot. The rendering changes reduce work without dropping any samples used by gesture recognition.

## Automated verification

The repository gate passes at commit `4751814`:

```text
./gradlew assembleDebug test lint
BUILD SUCCESSFUL
```

The debug JVM results contain 41 suites and 343 tests with zero failures, errors, or skips. `assembleRelease`, `lintDebug`, and `git diff --check` also pass.

Added/updated regression coverage verifies:

- queued tap-prefix decodes are coalesced to the latest generation
- a failed decode worker does not permanently stop future predictions
- squared tap-threshold comparisons preserve below/exactly/above-boundary classification

## A/B performance evidence

Methodology:

- baseline: `1fe33aa`; optimized: `4751814`
- matched interleaved order: B1 / O1 / B2 / O2
- verbose `DecodeTrace` formatting disabled in both benchmark APKs
- one compact candidate-callback timestamp used for tap measurements
- 50 warmed tap trials per variant
- high-rate synthetic swipes used for rendering stress

### Physical phone: nubia NX741J, Android 16, active 60 Hz

| Workload | Baseline | Optimized | Change |
|---|---:|---:|---:|
| rapid 10-tap `completion`, median final-candidate latency | 12 ms | 10 ms | -16.7% |
| rapid 10-tap `completion`, mean | 12.74 ms | 10.62 ms | -16.6% |
| rapid 10-tap `completion`, p95 | 22 ms | 18 ms | -18.2% |
| rapid 9-tap `something`, median | 11 ms | 11 ms | no measurable change |
| swipe rendering | 0 / 3,092 janky frames | 1 / 3,098 | baseline already within budget |

The mean saving for the heavier `completion` workload was 2.12 ms with a bootstrap 95% confidence interval of 0.4–3.9 ms. After installing the release build, normal keyboard use on this device also felt substantially more pleasant, although that observation is subjective and broader than the callback benchmark.

### Android 14 x86_64 emulator

| Workload | Baseline | Optimized | Change |
|---|---:|---:|---:|
| rapid `completion`, median | 19 ms | 16 ms | -15.8% |
| rapid `completion`, mean | 19.44 ms | 16.48 ms | -15.2% |
| rapid `completion`, p95 | 29 ms | 25 ms | -13.8% |
| high-rate swipe jank | 229 / 2,957 (7.74%) | 113 / 3,001 (3.77%) | -51.4% relative |
| swipe batch p95 | 34–36 ms | 16–19 ms | lower in every batch |

For emulator `completion`, the bootstrap 95% confidence interval for mean savings was 0.56–5.30 ms. The swipe jank-rate reduction was approximately 3.98 percentage points (95% CI 2.80–5.16, z=6.61).

## Manual verification

1. Enable Kinetica, focus a normal text field, and rapidly tap a multi-letter word. Expected: committed text and candidates track the latest prefix without a delayed stale candidate.
2. Hold and release backspace, then immediately type a new word. Expected: prediction resumes normally; no stranded decode worker.
3. Perform repeated dense swipes, including starting a second gesture before the previous trail fully fades. Expected: trails remain smooth and no line connects separate gestures.
4. Change trail hue through a chord/gesture transition. Expected: the color transition remains a distinct segment rather than being coalesced away.

## Measurement caveats

- Tap measurements cover injector completion to final candidate callback, not touch-to-character rendering.
- Zero-delay taps and 120-sample swipes are synthetic stress workloads, so absolute numbers should not be treated as normal human typing latency.
- The physical phone is fast enough that baseline swipe rendering already met its frame budget; the emulator better exposes the rendering-side difference.
- The ordinary `something` workload did not show a statistically clear phone improvement, so the evidence supports reduced worst-case work rather than a universal per-key speedup.
