### PR TITLE
engine(bigrams): merge counts for folded pairs

### DIFF
--- a/app/src/main/java/com/kinetica/keyboard/engine/BigramTable.kt
+++ b/app/src/main/java/com/kinetica/keyboard/engine/BigramTable.kt
@@ -31,26 +31,35 @@ class BigramTable private constructor(
         private fun pack(prev: Int, next: Int): Long =
             (prev.toLong() shl 32) or (next.toLong() and 0xFFFFFFFFL)
 
-        /** Entries are (prevWordId, nextWordId, rawCount). */
+        /** Entries are (prevWordId, nextWordId, rawCount); equal pairs sum their counts. */
         fun build(entries: List<Triple<Int, Int, Long>>): BigramTable {
             if (entries.isEmpty()) return EMPTY
             val keys = LongArray(entries.size)
             val counts = LongArray(entries.size)
             val idx = entries.indices.sortedBy { pack(entries[it].first, entries[it].second) }
-            for (i in idx.indices) {
-                val e = entries[idx[i]]
-                keys[i] = pack(e.first, e.second)
-                counts[i] = e.third
+            var uniqueCount = 0
+            for (i in idx) {
+                val e = entries[i]
+                val key = pack(e.first, e.second)
+                // Accent folding can make distinct spellings share a pair. Combine
+                // their evidence before finding the context maximum or quantizing.
+                if (uniqueCount > 0 && keys[uniqueCount - 1] == key) {
+                    counts[uniqueCount - 1] += e.third
+                } else {
+                    keys[uniqueCount] = key
+                    counts[uniqueCount] = e.third
+                    uniqueCount++
+                }
             }
             // Same-prev entries are contiguous after sorting; normalize each group
             // against its own maximum so every context uses the full byte range.
-            val boosts = ByteArray(entries.size)
+            val boosts = ByteArray(uniqueCount)
             var start = 0
-            while (start < keys.size) {
+            while (start < uniqueCount) {
                 val prev = keys[start] ushr 32
                 var end = start
                 var maxCount = 1L
-                while (end < keys.size && (keys[end] ushr 32) == prev) {
+                while (end < uniqueCount && (keys[end] ushr 32) == prev) {
                     maxCount = max(maxCount, counts[end])
                     end++
                 }
@@ -61,7 +70,7 @@ class BigramTable private constructor(
                 }
                 start = end
             }
-            return BigramTable(keys, boosts)
+            return BigramTable(keys.copyOf(uniqueCount), boosts)
         }
     }
 }

--- a/app/src/main/java/com/kinetica/keyboard/engine/DictionaryLoader.kt
+++ b/app/src/main/java/com/kinetica/keyboard/engine/DictionaryLoader.kt
@@ -103,7 +103,8 @@ object DictionaryLoader {
      * Lines of "w1&lt;TAB&gt;w2&lt;TAB&gt;count". Counts exceed Int range ("of the" in a
      * web corpus), hence Long. Pairs with endpoints missing from [trie] are
      * dropped: the table is keyed on trie node ids. Endpoints fold like
-     * wordlist entries so accented Italian bigrams resolve.
+     * wordlist entries so accented Italian bigrams resolve; [BigramTable]
+     * combines counts for spellings that resolve to the same pair.
      */
     fun loadBigrams(reader: BufferedReader, trie: Trie): BigramTable {
         val entries = ArrayList<Triple<Int, Int, Long>>(100_000)

--- a/app/src/test/java/com/kinetica/keyboard/engine/BigramTableTest.kt
+++ b/app/src/test/java/com/kinetica/keyboard/engine/BigramTableTest.kt
@@ -1,0 +1,100 @@
+package com.kinetica.keyboard.engine
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BigramTableTest {
+
+    @Test
+    fun duplicatePairRowOrderDoesNotChangeBoosts() {
+        val entries = listOf(
+            Triple(1, 2, 100L),
+            Triple(1, 2, 1L),
+            Triple(1, 3, 50L),
+        )
+        val forward = BigramTable.build(entries)
+        val reversed = BigramTable.build(entries.reversed())
+        for (next in listOf(2, 3)) {
+            assertEquals(forward.multiplier(1, next), reversed.multiplier(1, next), 0f)
+        }
+    }
+
+    @Test
+    fun duplicateCountsAreSummedBeforeContextNormalization() {
+        val split = BigramTable.build(
+            listOf(
+                Triple(1, 2, 60L),
+                Triple(1, 3, 100L),
+                Triple(1, 2, 50L),
+                Triple(2, 3, 30L),
+                Triple(2, 4, 50L),
+                Triple(2, 4, 20L),
+            ),
+        )
+        val combined = BigramTable.build(
+            listOf(
+                Triple(1, 2, 110L),
+                Triple(1, 3, 100L),
+                Triple(2, 3, 30L),
+                Triple(2, 4, 70L),
+            ),
+        )
+        assertEquals(4, split.size)
+        for ((prev, next) in listOf(1 to 2, 1 to 3, 2 to 3, 2 to 4)) {
+            assertEquals(combined.multiplier(prev, next), split.multiplier(prev, next), 0f)
+        }
+    }
+
+    @Test
+    fun accentedEndpointsMergeThroughDictionaryLoader() {
+        val trie = DictionaryLoader.loadWordlist(
+            "e\t100\nè\t90\nsi\t80\nsì\t70\nnon\t60\n".reader().buffered(),
+        )
+        val split = DictionaryLoader.loadBigrams(
+            "e\tsi\t60\nè\tsì\t50\ne\tnon\t100\n".reader().buffered(), trie,
+        )
+        val combined = DictionaryLoader.loadBigrams(
+            "e\tsi\t110\ne\tnon\t100\n".reader().buffered(), trie,
+        )
+        val prev = trie.nodeFor("e")
+        assertEquals(2, split.size)
+        for (next in listOf("si", "non")) {
+            val id = trie.nodeFor(next)
+            assertEquals(combined.multiplier(prev, id), split.multiplier(prev, id), 0f)
+        }
+    }
+
+    @Test
+    fun mergedCountsKeepLongRange() {
+        val split = BigramTable.build(
+            listOf(
+                Triple(1, 2, 3_000_000_000L),
+                Triple(1, 2, 3_000_000_000L),
+                Triple(1, 3, 5_000_000_000L),
+            ),
+        )
+        val combined = BigramTable.build(
+            listOf(Triple(1, 2, 6_000_000_000L), Triple(1, 3, 5_000_000_000L)),
+        )
+        for (next in listOf(2, 3)) {
+            assertEquals(combined.multiplier(1, next), split.multiplier(1, next), 0f)
+        }
+    }
+
+    @Test
+    fun uniquePairsKeepTheirQuantizedBoosts() {
+        val table = BigramTable.build(
+            listOf(Triple(1, 3, 15L), Triple(2, 3, 3L), Triple(1, 2, 3L)),
+        )
+        assertEquals(3, table.size)
+        // ln(1 + 3) / ln(1 + 15) = 1/2, quantized down to byte 127.
+        assertEquals(
+            1f + KineticaConstants.BIGRAM_BOOST_MAX * 127 / 255f,
+            table.multiplier(1, 2), 0f,
+        )
+        for (prev in listOf(1, 2)) {
+            assertEquals(1f + KineticaConstants.BIGRAM_BOOST_MAX, table.multiplier(prev, 3), 0f)
+        }
+        assertEquals(1f, table.multiplier(2, 2), 0f)
+    }
+}


### PR DESCRIPTION
Accent folding can map distinct bigram rows to the same word-ID pair. The table kept those duplicate keys, so binary search could select different counts when the same input rows were reordered.

Sum counts for equal pairs during the existing sorted pass, before per-context normalization. Keep one key and boost per pair. This preserves the scoring formula and lookup behavior for unique pairs.

Validation:

- Five focused tests cover input-order independence, aggregation before normalization, folding at both endpoints, Long counts, and unchanged unique-pair boosts. Four fail on the original implementation and all pass with the fix.
- `./gradlew assembleDebug test lint --rerun-tasks`: passed; 441 tests in each of debug and release, none skipped.
- Existing ranking, captured-gesture goldens, and latency tests pass.
- `git diff --check`: passed.
