### PR TITLE
ime(language): synchronize Android subtypes

### DIFF
--- a/app/src/main/java/com/kinetica/keyboard/ime/KineticaIME.kt
+++ b/app/src/main/java/com/kinetica/keyboard/ime/KineticaIME.kt
@@ -4,16 +4,20 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.inputmethodservice.InputMethodService
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.provider.Settings
 import android.util.Log
 import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InputMethodSubtype
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.preference.PreferenceManager
 import com.kinetica.keyboard.data.DictionaryStore
@@ -71,6 +75,10 @@ import java.util.concurrent.Executors
 class KineticaIME : InputMethodService(), GestureEngine.Listener, WordComposer.Callbacks {
 
     private val mainHandler = Handler(Looper.getMainLooper())
+    private val inputMethodManager by lazy { getSystemService(InputMethodManager::class.java) }
+    private val inputMethodInfo by lazy {
+        inputMethodManager.inputMethodList.first { it.packageName == packageName }
+    }
     private val mainExecutor = Executor { mainHandler.post(it) }
     private val decodeExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "kinetica-decode").apply { priority = Thread.NORM_PRIORITY + 1 }
@@ -266,6 +274,7 @@ class KineticaIME : InputMethodService(), GestureEngine.Listener, WordComposer.C
                 abandonWord()
                 keyboardView?.setKeyboardLayout(alphaLayout())
                 loadDictionaryAsync()
+                requestLanguageSubtype(config.language)
             } else if (config.dictionaryGeneration != previous.dictionaryGeneration ||
                 config.autoDetectLanguage != previous.autoDetectLanguage ||
                 config.enabledLanguages != previous.enabledLanguages
@@ -651,6 +660,7 @@ class KineticaIME : InputMethodService(), GestureEngine.Listener, WordComposer.C
 
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
+        synchronizeLanguageOnStart()
         editorState = EditorState.from(attribute)
         abandonWord()
         composer?.reset()
@@ -1845,6 +1855,59 @@ class KineticaIME : InputMethodService(), GestureEngine.Listener, WordComposer.C
             .edit().putBoolean(Prefs.PECK_MODE, !config.peckMode).apply()
     }
 
+    @Suppress("DEPRECATION") // method.xml declares legacy imeSubtypeLocale values.
+    private fun subtypeLanguage(subtype: InputMethodSubtype?): String? =
+        subtype?.locale?.substringBefore('_')
+
+    override fun onCurrentInputMethodSubtypeChanged(newSubtype: InputMethodSubtype?) {
+        val language = subtypeLanguage(newSubtype) ?: return
+        acceptSubtypeLanguage(language)
+    }
+
+    private fun acceptSubtypeLanguage(language: String) {
+        PreferenceManager.getDefaultSharedPreferences(this).edit()
+            .putString(Prefs.LANGUAGE, language)
+            .putString(Prefs.SYNCED_LANGUAGE, language)
+            .apply()
+    }
+
+    private fun synchronizeLanguageOnStart() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val systemLanguage = subtypeLanguage(inputMethodManager.currentInputMethodSubtype)
+        val language = languageOnInputStart(
+            prefs.getString(Prefs.LANGUAGE, null),
+            prefs.getString(Prefs.SYNCED_LANGUAGE, null),
+            systemLanguage,
+        )
+        if (language == systemLanguage) {
+            acceptSubtypeLanguage(language)
+        } else {
+            requestLanguageSubtype(language)
+        }
+    }
+
+    private fun requestLanguageSubtype(language: String) {
+        // A Settings edit can arrive while another IME is selected. Keep the
+        // local choice unacknowledged until this IME is active again.
+        if (Settings.Secure.getString(contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD) !=
+            inputMethodInfo.id
+        ) return
+        val subtype = (0 until inputMethodInfo.subtypeCount).asSequence()
+            .map { inputMethodInfo.getSubtypeAt(it) }
+            .firstOrNull { subtypeLanguage(it) == language } ?: return
+        if (subtype == inputMethodManager.currentInputMethodSubtype) {
+            acceptSubtypeLanguage(language)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            switchInputMethod(inputMethodInfo.id, subtype)
+        } else {
+            // The service overload was added in API 28; the IME token supplies
+            // the same authority through InputMethodManager on Android 8.
+            val token = window.window?.attributes?.token ?: return
+            @Suppress("DEPRECATION")
+            inputMethodManager.setInputMethodAndSubtype(token, inputMethodInfo.id, subtype)
+        }
+    }
+
     /** ?123-chord language switch: next enabled language in canonical order. */
     private fun cycleLanguage() {
         val langs = config.enabledLanguages
@@ -2030,6 +2093,20 @@ class KineticaIME : InputMethodService(), GestureEngine.Listener, WordComposer.C
         // Any-letter (accented Italian included) with internal apostrophes.
         val WORD_RE = Regex("^\\p{L}+(?:'\\p{L}+)*$")
     }
+}
+
+/**
+ * Choose the initial language without losing Settings edits made while the
+ * service was absent. An existing preference also wins on the first sync;
+ * once acknowledged, Android can select a different subtype on a cold start.
+ */
+internal fun languageOnInputStart(
+    storedLanguage: String?,
+    syncedLanguage: String?,
+    subtypeLanguage: String?,
+): String {
+    if (storedLanguage != null && storedLanguage != syncedLanguage) return storedLanguage
+    return subtypeLanguage ?: storedLanguage ?: Prefs.DEFAULT_LANGUAGE
 }
 
 /**

--- a/app/src/main/java/com/kinetica/keyboard/settings/Prefs.kt
+++ b/app/src/main/java/com/kinetica/keyboard/settings/Prefs.kt
@@ -141,6 +141,8 @@ object Prefs {
     const val TRAIL_COLOR = "pref_trail_color"
     const val TRAIL_COLOR_CUSTOM_HUE = "pref_trail_color_custom_hue"
     const val LANGUAGE = "pref_language"
+    /** Last language agreed with Android; detects Settings edits while the IME is inactive. */
+    const val SYNCED_LANGUAGE = "pref_synced_language"
     const val LONG_PRESS_MS = "pref_long_press_ms"
     const val AUTOCORRECT_LEVEL = "pref_autocorrect_level"
     const val REINFORCE_INCREMENT = "pref_reinforce_increment"

--- a/app/src/test/java/com/kinetica/keyboard/ime/LanguageSelectionTest.kt
+++ b/app/src/test/java/com/kinetica/keyboard/ime/LanguageSelectionTest.kt
@@ -1,0 +1,33 @@
+package com.kinetica.keyboard.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LanguageSelectionTest {
+
+    @Test
+    fun coldStartHonorsAndroidWhenLocalLanguageHasNotChanged() {
+        assertEquals("it", languageOnInputStart("en", "en", "it"))
+    }
+
+    @Test
+    fun settingsChangeWhileInactiveWinsOverOldAndroidSubtype() {
+        assertEquals("pl", languageOnInputStart("pl", "it", "it"))
+    }
+
+    @Test
+    fun firstRunUsesTheSelectedAndroidSubtype() {
+        assertEquals("it", languageOnInputStart(null, null, "it"))
+    }
+
+    @Test
+    fun firstSyncPreservesAnExistingLanguagePreference() {
+        assertEquals("pl", languageOnInputStart("pl", null, "en"))
+    }
+
+    @Test
+    fun absentSubtypeKeepsTheConfiguredLanguageOrDefault() {
+        assertEquals("pl", languageOnInputStart("pl", "pl", null))
+        assertEquals("en", languageOnInputStart(null, null, null))
+    }
+}


### PR DESCRIPTION
Selecting a language in Android's keyboard picker changed the system subtype while Kinetica kept using its previous layout and dictionary.

Handle subtype changes and startup selection through the existing language preference listener. Synchronize Settings and the language chord back to Android. Remember the last synchronized language so Settings edits made while the IME is inactive survive reactivation, and existing preferences survive the first synchronization.

Validation:

- `./gradlew assembleDebug test lint --rerun-tasks`: passed; 441 tests in each of debug and release, none skipped.
- Five JVM tests cover startup selection, inactive Settings edits, first use, existing preferences, and missing subtypes.
- `git diff --check`: passed.

Device checks passed on the Android 16 (API 36.1) emulator:

- Select Italiano in Android's picker: the keyboard shows IT and loads its Italian dictionary.
- Hold ?123 and tap L: the language advances and Android's selected subtype follows.
- Choose Polski in Kinetica Settings: the keyboard and Android both switch to Polish.
- Select another keyboard, choose Italiano in Kinetica Settings, then reactivate Kinetica: the Italian choice persists and synchronizes with Android.
- Restart the app and choose English in Android's picker: English loads. Hide and reopen the keyboard: English remains selected.

The language-switching fix was also verified on a physical device by the contributor.
